### PR TITLE
timing adjustments to checkExec

### DIFF
--- a/exercises/offloading_the_work/exercise.js
+++ b/exercises/offloading_the_work/exercise.js
@@ -138,7 +138,7 @@ function checkExec (mode, callback) {
 
     var delay = Date.now() - start
 
-    if (delay < 100 || delay > 300) {
+    if (delay < 100 || delay > 500) {
       exercise.emit('fail', 'Slept for the right amount of time (asked for 111ms, slept for ' + delay + ')')
       return callback(null, false)
     }
@@ -150,7 +150,7 @@ function checkExec (mode, callback) {
 
       delay = Date.now() - start
 
-      if (delay < 1000 || delay > 1300) {
+      if (delay < 1000 || delay > 1500) {
         exercise.emit('fail', 'Slept for the right amount of time (asked for 1111ms, slept for ' + delay + 'ms)')
         return callback(null, false)
       }


### PR DESCRIPTION
These changes enable my Linux set-up (details below) to pass the final offloading tutorial step. They are in this PR to create a discussion on whether they are necessary, or are due to other issues.

Edit: This may be the same problem reported in #38.

Without these changes, the actual sleep time exceeds the upper bound on both checks. For the first check, the sleep time is approx 370ms, and for the second, approx 1400ms. From memory and a quick google search, the time provided to Windows Sleep() is considered a guide only, and a wake time of 111ms is a bit on the low side. I have no personal coding experience of usleep() to comment on.

My set-up: Oracle VirtualBox VM running Ubuntu 12.04 LTS (32-bit) on a Windows host machine.

Testing: the changes have been tested as follows:

After creating a fork of goingnative, I copied my solution folder "myaddon" to the goingnative folder, and made the edits to the relevant exercise.js (in the "exercises\offloading*" folder). The code was tested several times in debug and normal mode.

The code was debugged with node-inspector: 
`node-debug goingnative.js verify myaddon`

The code was also run with the same command line, but just with node.
