### PR TITLE
Remove a space in the Apple LLVM check

### DIFF
--- a/exercises/am_i_ready/exercise.js
+++ b/exercises/am_i_ready/exercise.js
@@ -131,7 +131,7 @@ function checkGcc (pass, callback) {
             + chalk.bold('v' + MIN_GCC_VERSION)
         )
       }
-    } else if (versionMatch = stderr.toString().match(/Apple LLVM version (\d+\.\d+) /)) {
+    } else if (versionMatch = stderr.toString().match(/Apple LLVM version (\d+\.\d+)/)) {
       versionString = versionMatch && versionMatch[1] + '.0'
 
       if (!semver.satisfies(versionString, '>=' + MIN_LLVM_VERSION)) {


### PR DESCRIPTION
When running gcc -v on my Mac with the latest version of xcode, the following output came out:

```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 6.1.0 (clang-602.0.49) (based on LLVM 3.6.0svn)
Target: x86_64-apple-darwin14.3.0
Thread model: posix
```

However, when running `goingnative verify` for the first exercise, the exercise says ``` ✗ Unknown `gcc` found in $PATH ```.

This pull request fixes the error.