### PR TITLE
meta: fix node version check

### DIFF
--- a/exercises/am_i_ready/exercise.js
+++ b/exercises/am_i_ready/exercise.js
@@ -87,7 +87,7 @@ function checkNode (pass, callback) {
     return callback(null, false)
  }
 
- if (semver.gt(process.versions.node, MAX_NODE_VERSION)) {
+ if (semver.satisfies(process.versions.node, '~' + MAX_NODE_VERSION)) {
     exercise.emit('fail',
           '`'
         + chalk.bold('node')


### PR DESCRIPTION
currently the comparison for Node max version is using semver.gt

the gt method does not support variables in the semver

switching to the satisfies method as used in the Python check fixes this

fixes #72