### PR TITLE
Support for VistualStudio 2015 (Ver. 14.0)

### DIFF
--- a/exercises/am_i_ready/exercise.js
+++ b/exercises/am_i_ready/exercise.js
@@ -160,11 +160,12 @@ function checkGcc (pass, callback) {
 
 function checkMsvc (pass, callback) {
   var msvsVars    = {
-          2013: 'VS130COMNTOOLS'
+        2015: 'VSSDK140Install'
+        , 2013: 'VS130COMNTOOLS'
         , 2012: 'VS120COMNTOOLS'
         , 2011: 'VS110COMNTOOLS'
       }
-    , msvsVersion = Object.keys(msvsVars).filter(function (k) {
+    , msvsVersion = Object.keys(msvsVars).reverse().filter(function (k) {
         return !!process.env[msvsVars[k]]
       })[0]
 
@@ -177,7 +178,7 @@ function checkMsvc (pass, callback) {
     return callback(null, false)
   }
 
-  if (!fs.existsSync(path.join(process.env[msvsVars[msvsVersion]], 'vsvars32.bat'))) {
+  if (!fs.existsSync(path.join((process.env[msvsVars[msvsVersion]]).replace('VSSDK', 'Common7\\Tools'), 'vsvars32.bat'))) {
     exercise.emit('fail',
         'Check for '
       + chalk.bold('Microsoft Visual Studio')

--- a/exercises/am_i_ready/exercise.js
+++ b/exercises/am_i_ready/exercise.js
@@ -160,7 +160,7 @@ function checkGcc (pass, callback) {
 
 function checkMsvc (pass, callback) {
   var msvsVars    = {
-        2015: 'VSSDK140Install'
+        2015: 'VS140COMNTOOLS'
         , 2013: 'VS130COMNTOOLS'
         , 2012: 'VS120COMNTOOLS'
         , 2011: 'VS110COMNTOOLS'
@@ -178,7 +178,7 @@ function checkMsvc (pass, callback) {
     return callback(null, false)
   }
 
-  if (!fs.existsSync(path.join((process.env[msvsVars[msvsVersion]]).replace('VSSDK', 'Common7\\Tools'), 'vsvars32.bat'))) {
+  if (!fs.existsSync(path.join((process.env[msvsVars[msvsVersion]]), 'vsvars32.bat'))) {
     exercise.emit('fail',
         'Check for '
       + chalk.bold('Microsoft Visual Studio')


### PR DESCRIPTION
Support for VistualStudio 2015 (Ver. 14.0)
Environment variable is "VSSDK140Install => C:\Program Files (x86)\Microsoft Visual Studio 14.0\VSSDK\"
We need to reverse  Object.keys(msvsVars) before filter it, becourse 2015 has path form 2011~2013
