### PR TITLE
update Apple gcc version check

### DIFF
--- a/exercises/am_i_ready/exercise.js
+++ b/exercises/am_i_ready/exercise.js
@@ -118,8 +118,8 @@ function checkGcc (pass, callback) {
             chalk.bold('v' + MIN_GCC_VERSION)
         )
       }
-    } else if (stderr.toString().match(/Apple LLVM version (\d+\.\d+)/)) {
-      versionMatch = stderr.toString().match(/Apple LLVM version (\d+\.\d+)/)
+    } else if (stderr.toString().match(/Apple (?:LLVM|clang) version (\d+\.\d+)/)) {
+      versionMatch = stderr.toString().match(/Apple (?:LLVM|clang) version (\d+\.\d+)/)
       versionString = versionMatch && versionMatch[1] + '.0'
 
       if (!semver.satisfies(versionString, '>=' + MIN_LLVM_VERSION)) {


### PR DESCRIPTION
MacOS: allow term 'clang' additionally to 'LLVM' in gcc version string
Signed-off-by: Harald Fassler <harald.fassler+9974@gmail.com>

Apple seems to have changed the version string from "LLVM" to "clang":
```shell
% gcc -v            
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 12.0.5 (clang-1205.0.22.11)
Target: x86_64-apple-darwin20.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```
Therefor in the current version the first exercise fails with:
```sh
 ✗ 

 Unknown gcc found in $PATH
```
This pull request is to allow also "clang" in the version check.