### PR TITLE
fix task2 for windows cmd

### DIFF
--- a/exercises/mission_possible_part_two/exercise.js
+++ b/exercises/mission_possible_part_two/exercise.js
@@ -27,7 +27,7 @@ exercise.addProcessor(checkJs)
 exercise.addCleanup(copy.cleanup([copyFauxTempDir]))
 
 function copyFauxAddon (mode, callback) {
-  copy(path.join(__dirname, 'faux', 'myaddon.cc'), copyFauxTempDir, { overwrite: true }, function (err) {
+  copy(path.join(__dirname, 'faux', 'myaddon.cc'), path.join(copyFauxTempDir, "myaddon.cc"), { overwrite: true }, function (err) {
     if (err) { return callback(err) }
 
     callback(null, true)
@@ -50,7 +50,7 @@ function checkJs (mode, callback) {
 
     execWith(
       require.resolve('../../lib/require-argv2'),
-      copyFauxTempDir,
+      path.join(copyFauxTempDir, "build", "Release", "myaddon"),
       'FAUX\n',
       function (err, pass) {
         if (err) {

--- a/lib/execWith.js
+++ b/lib/execWith.js
@@ -16,7 +16,7 @@ function execWith (dir, arg, expect, options, callback) {
     callback = options
   }
 
-  exec(`'${process.execPath}' '${dir}' '${arg}'`, function (err, stdout, stderr) {
+  exec(`"${process.execPath}" "${dir}" "${arg}"`, function (err, stdout, stderr) {
     if (err) {
       process.stderr.write(stderr)
       process.stdout.write(stdout)


### PR DESCRIPTION
This is concerned with #99.

My modification

1. add path.join, otherwise `copy` function can not properly copy the cc file to the temporary folder
2. replace the single quotation marks with the double quotation marks, otherwise will get `The filename, directory name, or volume label syntax is incorrect.` on windows cmd.